### PR TITLE
feat: Make RGB/HSL patterns configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,35 @@ yourself. These commands are the following:
 
 ```lua
 {
-  hsl_pattern = "hsl(%d, %g%%, %g%%)",
-  hsla_pattern = "hsla(%d, %d%%, %d%%, %g)",
-  rgb_pattern = "rgb(%d, %d, %d)",
-  rgba_pattern = "rgba(%d, %d, %d, %g)",
+  hsl_pattern = "hsl([h]deg [s] [l])",
+  hsla_pattern = "hsl([h]deg [s] [l] / [a]%)",
+  rgb_pattern = "rgb([r] [g] [b])",
+  rgba_pattern = "rgb([r] [g] [b] / [a]%)",
 }
 ```
 
-You can update the patterns to use modern syntax without the comma separator, ie.
-`hsl_pattern = "hsl(%d %g%% %g%%)"`
+#### Patterns
+HSL/RGB colors can be expressed in many different ways, it's therefore possible
+to configure which one to use when generating/converting colors.
+
+This plugin aims to correctly convert HSL/RGB colors regardless of which syntax
+was used to write them. However one has to be chosen when generating a new
+color.
+
+See [hsl()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl) and [rgb()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb) for more information.
+
+The following rules apply to the color patterns:
+- Only known tokens will be replaced, unknown tokens and text oustide `[]` will be kept as is.
+  The following tokens are supported: `[h]`, `[s]`, `[l]`, `[r]`, `[g]`, `[b]`, `[a]`.
+- You can add the `%` suffix to any token to represent the value as a percentage.
+
+Example patterns (example values are included for clarity):
+- `hsl([h:180]deg [s:0] [l:50] / [a:0.5]%)` -> `hsl(180deg 0 50 / 50%)`
+- `hsl([h:180] [s:0]% [l:50]% / [a:0.5])` -> `hsl(180 0% 50% / 0.5)`
+- `hsl([h:180]deg, [s:0], [l:50])` -> `hsl(180deg, 0, 50)`
+- `rgb([r:255] [g:0] [b:0] / [a:0.5]%)` -> `rgb(255 0 0 / 50%)`
+- `rgb([r:255]% [g:0]% [b:0]% / [a:0.5])` -> `rgb(100% 0% 0% / 0.5)`
+- `rgb([r:255], [g:0], [b:0])` -> `rgb(255, 0, 0)`
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Easily convert your CSS colors without leaving your favorite editor.
 Packer
 ```lua
 use 'NTBBloodbath/color-converter.nvim'
+require('color-converter').setup({})
+```
+
+Lazy
+```lua
+return {
+  "NTBBloodbath/color-converter.nvim",
+  opts = {},
+}
 ```
 
 ## Usage
@@ -44,6 +53,21 @@ yourself. These commands are the following:
   - Convert the current color to `RGB`.
 - `<Plug>ColorConvertHSL`
   - Convert the current color to `HSL`.
+
+### Configuration
+  This is the default configuration:
+
+```lua
+{
+  hsl_pattern = "hsl(%d, %g%%, %g%%)",
+  hsla_pattern = "hsla(%d, %d%%, %d%%, %g)",
+  rgb_pattern = "rgb(%d, %d, %d)",
+  rgba_pattern = "rgba(%d, %d, %d, %g)",
+}
+```
+
+You can update the patterns to use modern syntax without the comma separator, ie.
+`hsl_pattern = "hsl(%d %g%% %g%%)"`
 
 ## Acknowledgements
 

--- a/lua/color-converter.lua
+++ b/lua/color-converter.lua
@@ -1,220 +1,111 @@
-local converter = require('color-converter.converter')
-local function round(num)
-    if num % 1 >= 0.5 then
-        return math.ceil(num)
-    else
-        return math.floor(num)
-    end
-end
+local converter = require("color-converter.converter")
+local utils = require("color-converter.utils")
 local M = {}
 
 -- {{{ Some local DRY utilities
 
 local function from_HSL_to_RGB(color_line)
-	local hsl_colors = {}
-	local is_hsla = false
-
-	-- Try to detect HSL before HSLA
-	local hsl = color_line:gmatch('hsl%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?%)')()
+	local hsl = utils.extract_hsl(color_line)
 	if not hsl then
-		hsl = color_line:gmatch('hsla%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?,?%s?[.%d]+%)')()
-		is_hsla = true
+		return
 	end
 
-	-- Remove the "hsl(", ");", "%" and leave only the numbers before
-	-- splitting the string
-	for _, color_part in ipairs(
-		vim.split(is_hsla and hsl:gsub('hsla%(', ''):gsub('%);?', ''):gsub('%%', '') or hsl:gsub('hsl%(', ''):gsub('%);?', ''):gsub('%%', ''), '[, ]')
-	) do
-		hsl_colors[#hsl_colors + 1] = tonumber(color_part)
+	local rgb_colors = converter.HSL_to_RGB(hsl.h, hsl.s, hsl.l, hsl.a)
+	local pattern = require("config").options.rgb_pattern
+	if hsl.a then
+		pattern = require("config").options.rgba_pattern
 	end
-	local rgb_colors
-	if is_hsla then
-		rgb_colors = converter.HSL_to_RGB(
-			hsl_colors[1],
-			hsl_colors[2],
-			hsl_colors[3],
-			hsl_colors[4]
-		)
-		vim.cmd(
-			string.format(
-				's/%s/' .. require('config').options.rgba_pattern,
-				hsl,
-				rgb_colors[1],
-				rgb_colors[2],
-				rgb_colors[3],
-				rgb_colors[4]
-			)
-		)
-	else
-		rgb_colors = converter.HSL_to_RGB(
-			hsl_colors[1],
-			hsl_colors[2],
-			hsl_colors[3]
-		)
-		vim.cmd(
-			string.format(
-				's/%s/' .. require('config').options.rgb_pattern,
-				hsl,
-				rgb_colors[1],
-				rgb_colors[2],
-				rgb_colors[3]
-			)
-		)
-	end
+
+	vim.cmd(string.format(
+		"s/%s/%s",
+		hsl.str:gsub("/", "\\/"),
+		utils.replace_tokens_in_pattern(pattern, {
+			r = rgb_colors[1],
+			g = rgb_colors[2],
+			b = rgb_colors[3],
+			a = rgb_colors[4],
+		})
+	))
 end
 
 local function from_HSL_to_Hex(color_line)
-	local hsl_colors = {}
-	local is_hsla = false
-
-	-- Try to detect HSL before HSLA
-	local hsl = color_line:gmatch('hsl%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?%)')()
-	if not hsl then
-		hsl = color_line:gmatch('hsla%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?,?%s?[.%d]+%)')()
-		is_hsla = true
+	local hsl = utils.extract_hsl(color_line)
+	if hsl then
+		local hex_color = converter.HSL_to_Hex(hsl.h, hsl.s, hsl.l, hsl.a)
+		vim.cmd(string.format("s/%s/%s", hsl.str:gsub("/", "\\/"), hex_color))
 	end
-
-	-- Remove the "hsl(" / "hsla(", ");", "%" and leave only the numbers before
-	-- splitting the string
-	for _, color_part in ipairs(
-		vim.split(
-			is_hsla and hsl:gsub('hsla%(', ''):gsub('%);?', ''):gsub('%%', '')
-				or hsl:gsub('hsl%(', ''):gsub('%);?', ''):gsub('%%', ''),
-            '[, ]'
-		)
-	) do
-		hsl_colors[#hsl_colors + 1] = tonumber(color_part)
-	end
-	local hex_color = converter.HSL_to_Hex(
-		hsl_colors[1],
-		hsl_colors[2],
-		hsl_colors[3]
-	)
-	vim.cmd(string.format('s/%s/%s', hsl, hex_color))
 end
 
 local function from_RGB_to_HSL(color_line)
-    local rgb_colors = {}
-    local is_rgba = false
+	local rgb = utils.extract_rgb(color_line)
+	if not rgb then
+		return
+	end
 
-    -- Try to detect RGB before RGBA
-    local rgb = color_line:gmatch('rgb%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?%)')()
-    if not rgb then
-        rgb = color_line:gmatch('rgba%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?,?%s?[.%d]+%)')()
-        is_rgba = true
-    end
+	local hsl_colors = converter.RGB_to_HSL(rgb.r, rgb.g, rgb.b, rgb.a)
+	local pattern = require("config").options.hsl_pattern
+	if rgb.a then
+		pattern = require("config").options.hsla_pattern
+	end
 
-    -- Remove the "rgb(" / "rgba(", ");" and leave only the numbers before
-    -- splitting the string
-    for _, color_part in ipairs(
-        vim.split(
-            is_rgba and rgb:gsub('rgba%(', ''):gsub('%);?', '')
-                or rgb:gsub('rgb%(', ''):gsub('%);?', ''),
-           '[, ]'
-        )
-    ) do
-        rgb_colors[#rgb_colors + 1] = tonumber(color_part)
-    end
-
-    local hsl_color
-    if is_rgba then
-        hsl_color = converter.RGB_to_HSL(
-            rgb_colors[1],
-            rgb_colors[2],
-            rgb_colors[3],
-            rgb_colors[4]
-        )
-        -- Apply rounding to saturation and lightness values
-        vim.cmd(
-            string.format(
-                's/%s/' .. require('config').options.hsla_pattern,
-                rgb,
-                round(hsl_color[1]),
-                round(hsl_color[2]),
-                round(hsl_color[3]),
-                hsl_color[4]
-            )
-        )
-    else
-        hsl_color = converter.RGB_to_HSL(
-            rgb_colors[1],
-            rgb_colors[2],
-            rgb_colors[3]
-        )
-        -- Apply rounding to saturation and lightness values
-        vim.cmd(
-            string.format(
-                's/%s/' .. require('config').options.hsl_pattern,
-                rgb,
-                round(hsl_color[1]),
-                round(hsl_color[2]),
-                round(hsl_color[3])
-            )
-        )
-    end
+	-- Apply rounding to saturation and lightness values
+	vim.cmd(string.format(
+		"s/%s/%s",
+		rgb.str:gsub("/", "\\/"),
+		utils.replace_tokens_in_pattern(pattern, {
+			h = utils.round_float(hsl_colors[1], 0),
+			s = utils.round_float(hsl_colors[2], 0),
+			l = utils.round_float(hsl_colors[3], 0),
+			a = hsl_colors[4],
+		})
+	))
 end
 local function from_RGB_to_Hex(color_line)
-	local rgb_colors = {}
-	local is_rgba = false
-
-	-- Try to detect RGB before RGBA
-	local rgb = color_line:gmatch('rgb%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?%)')()
-	if not rgb then
-		rgb = color_line:gmatch('rgba%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?,?%s?[.%d]+%)')()
-		is_rgba = true
+	local rgb = utils.extract_rgb(color_line)
+	if rgb then
+		local hex_color = converter.RGB_to_Hex(rgb.r, rgb.g, rgb.b, rgb.a)
+		vim.cmd(string.format("s/%s/%s", rgb.str:gsub("/", "\\/"), hex_color))
 	end
-	-- Remove the "rgb(", ");" and leave only the numbers before
-	-- splitting the string
-	for _, color_part in ipairs(
-		vim.split(
-			is_rgba and rgb:gsub('rgba%(', ''):gsub('%);?', '')
-				or rgb:gsub('rgb%(', ''):gsub('%);?', ''),
-			'[, ]'
-		)
-	) do
-		rgb_colors[#rgb_colors + 1] = tonumber(color_part)
-	end
-	local hex_color = converter.RGB_to_Hex(
-		rgb_colors[1],
-		rgb_colors[2],
-		rgb_colors[3]
-	)
-	vim.cmd(string.format('s/%s/%s', rgb, hex_color))
 end
 
 local function from_Hex_to_HSL(color_line)
-	local hex = color_line:gmatch('#%w+')()
-	-- Remove the trailing semicolon, we don't need it
-	hex = hex:gsub(';?', '')
-
+	local hex = color_line:gmatch("(#%w+);?")()
 	local hsl_color = converter.Hex_to_HSL(hex)
-	vim.cmd(
-		string.format(
-			's/%s/' .. require('config').options.hsl_pattern,
-			hex,
-			hsl_color[1],
-			hsl_color[2],
-			hsl_color[3]
-		)
-	)
+	local pattern = require("config").options.hsl_pattern
+	if hsl_color[4] then
+		pattern = require("config").options.hsla_pattern
+	end
+
+	vim.cmd(string.format(
+		"s/%s/%s",
+		hex,
+		utils.replace_tokens_in_pattern(pattern, {
+			h = hsl_color[1],
+			s = hsl_color[2],
+			l = hsl_color[3],
+			a = hsl_color[4],
+		})
+	))
 end
 
 local function from_Hex_to_RGB(color_line)
-	local hex = color_line:gmatch('#%w+')()
-	-- Remove the trailing semicolon, we don't need it
-	hex = hex:gsub(';?', '')
-
+	local hex = color_line:gmatch("(#%w+);?")()
 	local rgb_color = converter.Hex_to_RGB(hex)
-	vim.cmd(
-		string.format(
-			's/%s/' .. require('config').options.rgb_pattern,
-			hex,
-			rgb_color[1],
-			rgb_color[2],
-			rgb_color[3]
-		)
-	)
+	local pattern = require("config").options.rgb_pattern
+	if rgb_color[4] then
+		pattern = require("config").options.rgba_pattern
+	end
+
+	vim.cmd(string.format(
+		"s/%s/%s",
+		hex,
+		utils.replace_tokens_in_pattern(pattern, {
+			r = rgb_color[1],
+			g = rgb_color[2],
+			b = rgb_color[3],
+			a = rgb_color[4],
+		})
+	))
 end
 
 -- }}}
@@ -267,8 +158,9 @@ M.cycle = function()
 	end
 end
 
+---@param options Config: user defined configuration options.
 M.setup = function(options)
-    require("config").__setup(options)
+	require("config").__setup(options)
 end
 
 return M

--- a/lua/color-converter.lua
+++ b/lua/color-converter.lua
@@ -15,16 +15,16 @@ local function from_HSL_to_RGB(color_line)
 	local is_hsla = false
 
 	-- Try to detect HSL before HSLA
-	local hsl = color_line:gmatch('hsl%(%d+,%s?[.%d]+%%?,%s?[.%d]+%%?%)')()
+	local hsl = color_line:gmatch('hsl%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?%)')()
 	if not hsl then
-		hsl = color_line:gmatch('hsla%(%d+,%s?[.%d]+%%?,%s?[.%d]+%%?,%s?[.%d]+%)')()
+		hsl = color_line:gmatch('hsla%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?,?%s?[.%d]+%)')()
 		is_hsla = true
 	end
 
 	-- Remove the "hsl(", ");", "%" and leave only the numbers before
 	-- splitting the string
 	for _, color_part in ipairs(
-		vim.split(is_hsla and hsl:gsub('hsla%(', ''):gsub('%);?', ''):gsub('%%', '') or hsl:gsub('hsl%(', ''):gsub('%);?', ''):gsub('%%', ''), ',')
+		vim.split(is_hsla and hsl:gsub('hsla%(', ''):gsub('%);?', ''):gsub('%%', '') or hsl:gsub('hsl%(', ''):gsub('%);?', ''):gsub('%%', ''), '[, ]')
 	) do
 		hsl_colors[#hsl_colors + 1] = tonumber(color_part)
 	end
@@ -38,7 +38,7 @@ local function from_HSL_to_RGB(color_line)
 		)
 		vim.cmd(
 			string.format(
-				's/%s/rgba(%d, %d, %d, %g)',
+				's/%s/' .. require('config').options.rgba_pattern,
 				hsl,
 				rgb_colors[1],
 				rgb_colors[2],
@@ -54,7 +54,7 @@ local function from_HSL_to_RGB(color_line)
 		)
 		vim.cmd(
 			string.format(
-				's/%s/rgb(%d, %d, %d)',
+				's/%s/' .. require('config').options.rgb_pattern,
 				hsl,
 				rgb_colors[1],
 				rgb_colors[2],
@@ -69,9 +69,9 @@ local function from_HSL_to_Hex(color_line)
 	local is_hsla = false
 
 	-- Try to detect HSL before HSLA
-	local hsl = color_line:gmatch('hsl%(%d+,%s?[.%d]+%%?,%s?[.%d]+%%?%)')()
+	local hsl = color_line:gmatch('hsl%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?%)')()
 	if not hsl then
-		hsl = color_line:gmatch('hsla%(%d+,%s?[.%d]+%%?,%s?[.%d]+%%?,%s?[.%d]+%)')()
+		hsl = color_line:gmatch('hsla%(%d+,?%s?[.%d]+%%?,?%s?[.%d]+%%?,?%s?[.%d]+%)')()
 		is_hsla = true
 	end
 
@@ -81,7 +81,7 @@ local function from_HSL_to_Hex(color_line)
 		vim.split(
 			is_hsla and hsl:gsub('hsla%(', ''):gsub('%);?', ''):gsub('%%', '')
 				or hsl:gsub('hsl%(', ''):gsub('%);?', ''):gsub('%%', ''),
-			','
+            '[, ]'
 		)
 	) do
 		hsl_colors[#hsl_colors + 1] = tonumber(color_part)
@@ -99,9 +99,9 @@ local function from_RGB_to_HSL(color_line)
     local is_rgba = false
 
     -- Try to detect RGB before RGBA
-    local rgb = color_line:gmatch('rgb%(%d+%%?,%s?%d+%%?,%s?%d+%%?%)')()
+    local rgb = color_line:gmatch('rgb%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?%)')()
     if not rgb then
-        rgb = color_line:gmatch('rgba%(%d+%%?,%s?%d+%%?,%s?%d+%%?,%s?[.%d]+%)')()
+        rgb = color_line:gmatch('rgba%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?,?%s?[.%d]+%)')()
         is_rgba = true
     end
 
@@ -111,7 +111,7 @@ local function from_RGB_to_HSL(color_line)
         vim.split(
             is_rgba and rgb:gsub('rgba%(', ''):gsub('%);?', '')
                 or rgb:gsub('rgb%(', ''):gsub('%);?', ''),
-            ','
+           '[, ]'
         )
     ) do
         rgb_colors[#rgb_colors + 1] = tonumber(color_part)
@@ -128,7 +128,7 @@ local function from_RGB_to_HSL(color_line)
         -- Apply rounding to saturation and lightness values
         vim.cmd(
             string.format(
-                's/%s/hsla(%d, %d%%, %d%%, %g)',
+                's/%s/' .. require('config').options.hsla_pattern,
                 rgb,
                 round(hsl_color[1]),
                 round(hsl_color[2]),
@@ -145,7 +145,7 @@ local function from_RGB_to_HSL(color_line)
         -- Apply rounding to saturation and lightness values
         vim.cmd(
             string.format(
-                's/%s/hsl(%d, %d%%, %d%%)',
+                's/%s/' .. require('config').options.hsl_pattern,
                 rgb,
                 round(hsl_color[1]),
                 round(hsl_color[2]),
@@ -159,9 +159,9 @@ local function from_RGB_to_Hex(color_line)
 	local is_rgba = false
 
 	-- Try to detect RGB before RGBA
-	local rgb = color_line:gmatch('rgb%(%d+%%?,%s?%d+%%?,%s?%d+%%?%)')()
+	local rgb = color_line:gmatch('rgb%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?%)')()
 	if not rgb then
-		rgb = color_line:gmatch('rgba%(%d+%%?,%s?%d+%%?,%s?%d+%%?,%s?[.%d]+%)')()
+		rgb = color_line:gmatch('rgba%(%d+%%?,?%s?%d+%%?,?%s?%d+%%?,?%s?[.%d]+%)')()
 		is_rgba = true
 	end
 	-- Remove the "rgb(", ");" and leave only the numbers before
@@ -170,7 +170,7 @@ local function from_RGB_to_Hex(color_line)
 		vim.split(
 			is_rgba and rgb:gsub('rgba%(', ''):gsub('%);?', '')
 				or rgb:gsub('rgb%(', ''):gsub('%);?', ''),
-			','
+			'[, ]'
 		)
 	) do
 		rgb_colors[#rgb_colors + 1] = tonumber(color_part)
@@ -191,7 +191,7 @@ local function from_Hex_to_HSL(color_line)
 	local hsl_color = converter.Hex_to_HSL(hex)
 	vim.cmd(
 		string.format(
-			's/%s/hsl(%d, %g%%, %g%%)',
+			's/%s/' .. require('config').options.hsl_pattern,
 			hex,
 			hsl_color[1],
 			hsl_color[2],
@@ -208,7 +208,7 @@ local function from_Hex_to_RGB(color_line)
 	local rgb_color = converter.Hex_to_RGB(hex)
 	vim.cmd(
 		string.format(
-			's/%s/rgb(%d, %d, %d)',
+			's/%s/' .. require('config').options.rgb_pattern,
 			hex,
 			rgb_color[1],
 			rgb_color[2],
@@ -265,6 +265,10 @@ M.cycle = function()
 	elseif current_line:find('hsl') then
 		from_HSL_to_Hex(current_line)
 	end
+end
+
+M.setup = function(options)
+    require("config").__setup(options)
 end
 
 return M

--- a/lua/color-converter/converter.lua
+++ b/lua/color-converter/converter.lua
@@ -6,8 +6,12 @@ local M = {}
 -- @param r Red value
 -- @param g Green value
 -- @param b Blue value
+-- @param a Alpha value
 -- @return HEX color, e.g. '#1E1E1E'
-M.RGB_to_Hex = function(r, g, b)
+M.RGB_to_Hex = function(r, g, b, a)
+  if a then
+    return '#' .. string.format('%02X%02X%02X%02X', r, g, b, 255 * a)
+  end
 	return '#' .. string.format('%02X%02X%02X', r, g, b)
 end
 
@@ -49,8 +53,6 @@ M.Hex_to_RGB = function(color)
 			tonumber('0x' .. color:sub(5, 6)),
 		}
 	elseif color:len() == 8 then
-		-- NOTE: unused at the moment
-		-- #RRGGBBAA
 		return {
 			tonumber('0x' .. color:sub(1, 2)),
 			tonumber('0x' .. color:sub(3, 4)),
@@ -91,7 +93,6 @@ M.HSL_to_RGB = function(h, s, l, a)
 	h = h / 360
 	s = s / 100
 	l = l / 100
-	a = a and a / 100 or l
 	local r, g, b
 
 	-- achromatic
@@ -125,7 +126,6 @@ M.RGB_to_HSL = function(r, g, b, a)
 	r = r / 255
 	g = g / 255
 	b = b / 255
-	a = a and a or 0
 
 	local c_max = math.max(r, g, b)
 	local c_min = math.min(r, g, b)
@@ -171,9 +171,9 @@ M.Hex_to_HSL = function(color)
 	end
 end
 
-M.HSL_to_Hex = function(h, s, l)
-	local rgb = M.HSL_to_RGB(h, s, l)
-	return M.RGB_to_Hex(rgb[1], rgb[2], rgb[3])
+M.HSL_to_Hex = function(h, s, l, a)
+	local rgb = M.HSL_to_RGB(h, s, l, a)
+	return M.RGB_to_Hex(rgb[1], rgb[2], rgb[3], rgb[4])
 end
 
 return M

--- a/lua/color-converter/utils.lua
+++ b/lua/color-converter/utils.lua
@@ -1,8 +1,119 @@
 local M = {}
 
 M.round_float = function(num, decimal_points)
-    local decimal = math.pow(10, decimal_points)
-    return math.floor(num * decimal + 0.5) / decimal
+  local decimal = math.pow(10, decimal_points)
+  return math.floor(num * decimal + 0.5) / decimal
+end
+
+--- Converts an <alpha-value> to a decimal value.
+---
+--- An <alpha-value> is defined as either a number between 0 and 1, or a
+--- percentage between 0% and 100%.
+--- @see https://developer.mozilla.org/en-US/docs/Web/CSS/alpha-value
+---
+--- @param alpha string -- the alpha-value string
+--- @return number|nil -- the alpha value as a number between 0 and 1
+local function alpha_value_to_decimal(alpha)
+  if alpha == "none" or string.len(alpha) < 1 then
+    return nil
+  end
+
+  local alpha_num = tonumber(alpha:gsub("%%", ""), 10)
+
+  -- Make sure that alpha is always returned as a percentage.
+  if alpha:match("%%") then
+    return alpha_num / 100
+  end
+
+  return alpha_num
+end
+
+--- Extract h, s, l, a values from color string.
+---
+--- We need to support both the legacy format and the modern format.
+---   <legacy-hsl-syntax> = hsl(<hue> , <percentage> , <percentage> , <alpha-value>?)
+---   <modern-hsl-syntax> = hsl([<hue>|none] [<percentage>|<number>|none] [<percentage>|<number>|none] [ / [<alpha-value>|none]]?)
+--- @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl#values
+---
+--- @param color_string string -- the HSL color string.
+--- @return { str: string, h: number, s: number, l: number, a: number|nil }|nil
+M.extract_hsl = function(color_string)
+  local str, h, s, l, a = color_string:gmatch("(hsla?%(([^ /,]+)[, ]+([^ /,]+)[, ]+([^ /,]+)[ /,]*([^ /,]*)%))")()
+  if not str then
+    return nil
+  end
+
+  local result = { str = str }
+  result.h = tonumber(h:gsub("deg", ""):gsub("none", 0), 10)
+  result.s = tonumber(s:gsub("%%", ""):gsub("none", 0), 10)
+  result.l = tonumber(l:gsub("%%", ""):gsub("none", 0), 10)
+  result.a = alpha_value_to_decimal(a)
+  return result
+end
+
+--- Extract r, g, b, a values from color string.
+---
+--- We need to support both the legacy format and the modean format.
+---   <legacy-rgb-syntax> = rgb([<percentage>|<number>]{3} , <alpha-value>?)
+---   <modern-rgb-syntax> = rgb([<percentage>|<number>|none]{3} [ / [<alpha-value>|none]]?)
+--- @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb#values
+---
+--- @param color_string string -- the RGB color string.
+--- @return { str: string, r: number, g: number, b: number, a: number|nil }|nil
+M.extract_rgb = function(color_string)
+  local str, r, g, b, a = color_string:gmatch("(rgba?%(([^ /,]+)[, ]+([^ /,]+)[, ]+([^ /,]+)[ /,]*([^ /,]*)%))")()
+  if not str then
+    return nil
+  end
+
+  local result = { str = str }
+  -- Convert percentage to value between 0 and 255.
+  result.r = tonumber(r:gsub("%%", ""):gsub("none", 0), 10)
+  if r:match("%%") then
+    result.r = 255 * result.r / 100
+  end
+
+  result.g = tonumber(g:gsub("%%", ""):gsub("none", 0), 10)
+  -- Convert percentage to value between 0 and 255.
+  if g:match("%%") then
+    result.g = 255 * result.g / 100
+  end
+
+  result.b = tonumber(b:gsub("%%", ""):gsub("none", 0), 10)
+  -- Convert percentage to value between 0 and 255.
+  if r:match("%%") then
+    result.b = 255 * result.b / 100
+  end
+
+  result.a = alpha_value_to_decimal(a)
+  return result
+end
+
+--- Replace tokens in a given RGB/HSL color pattern.
+---
+--- Example: replace_tokens_in_pattern('rgb([r]% [g]% [b]%)', { r=255, g=0, b=0 })
+--- Output : 'rgb(100% 0% 0%)'
+---
+--- @param pattern string -- the color pattern with tokens.
+--- @param tokens table -- a table of tokens keyed by token name.
+--- @return string -- the pattern with tokens replaced.
+M.replace_tokens_in_pattern = function(pattern, tokens)
+  pattern = pattern:gsub("%%", "%%"):gsub("/", "\\/")
+  for k, v in pairs(tokens) do
+    -- Try to replace percentage placeholders first.
+    if pattern:match("%[" .. k .. "%]%%") then
+      if k == 'a' then
+        v = v * 100
+      elseif k == 'r' or k == 'g' or k == 'b' then
+        v = v / 255 * 100
+      end
+      pattern = pattern:gsub("%[" .. k .. "%]%%", v .. "%%")
+    else
+      pattern = pattern:gsub("%[" .. k .. "%]", v)
+    end
+  end
+
+  return pattern
 end
 
 return M

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+M.defaults = {
+  hsl_pattern = "hsl(%d, %g%%, %g%%)",
+  hsla_pattern = "hsla(%d, %d%%, %d%%, %g)",
+  rgb_pattern = "rgb(%d, %d, %d)",
+  rgba_pattern = "rgba(%d, %d, %d, %g)",
+}
+
+M.options = {}
+
+M.__setup = function(options)
+  M.options = vim.tbl_deep_extend("force", {}, M.defaults, options or {})
+end
+
+return M

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,14 +1,23 @@
+---@class ConfigModule
+---@field defaults Config: default options.
+---@field options Config: config table extending defaults.
 local M = {}
 
 M.defaults = {
-  hsl_pattern = "hsl(%d, %g%%, %g%%)",
-  hsla_pattern = "hsla(%d, %d%%, %d%%, %g)",
-  rgb_pattern = "rgb(%d, %d, %d)",
-  rgba_pattern = "rgba(%d, %d, %d, %g)",
+  hsl_pattern = "hsl([h]deg [s] [l])",
+  hsla_pattern = "hsl([h]deg [s] [l] / [a]%)",
+  rgb_pattern = "rgb([r] [g] [b])",
+  rgba_pattern = "rgb([r] [g] [b] / [a]%)",
 }
 
+---@class Config
+---@field hsl_pattern string: the hsl pattern used when generating colors.
+---@field hsla_pattern string: the hsla pattern used when generating colors.
+---@field rgb_pattern string: the rgb pattern used when generating colors.
+---@field rgba_pattern string: the rgba pattern used when generating colors.
 M.options = {}
 
+---@param options Config: user defined config to override the defaults.
 M.__setup = function(options)
   M.options = vim.tbl_deep_extend("force", {}, M.defaults, options or {})
 end


### PR DESCRIPTION
The comma separated syntax for HSL and RGB is the legacy format according to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl)

That page states:
> Note: hsl()/hsla() can also be written in a legacy form in which all values are separated with commas, for example hsl(120, 75%, 25%) or hsla(120deg, 75%, 25%, 0.8). The none value is not permitted in the comma-separated legacy syntax, the deg on the hue value is optional, and the % units are required for the saturation and lightness values.

This PR adds support for using spaces as separator in HSL/RGB colors as well as making the output format configurable.