### PR TITLE
Feature: Format picker, lowercase HEX and cursor improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,19 @@ containing the CSS color and trigger the command that you want.
 ### Commands
 
 `color-converter.nvim` respects your keyboard shortcuts, so it doesn't create
-any by default. Instead, expose commands so you can create keyboard shortcuts
-yourself. These commands are the following:
+any by default. Instead, expose functions so you can create keyboard shortcuts
+yourself. These functions are the following:
 
-- `<Plug>ColorConvertCycle`
+- `require('color-converter').cycle()`
   - Cycle between `HEX`, `RGB` and `HSL`.
-- `<Plug>ColorConvertHEX`
+- `require('color-converter').to_hex()`
   - Convert the current color to `HEX`.
-- `<Plug>ColorConvertRGB`
+- `require('color-converter').to_rgb()`
   - Convert the current color to `RGB`.
-- `<Plug>ColorConvertHSL`
+- `require('color-converter').to_hsl()`
   - Convert the current color to `HSL`.
+- `require('color-converter').pick()`
+  - Pick between all of the available formats.
 
 ### Configuration
   This is the default configuration:
@@ -106,7 +108,7 @@ Example patterns (example values are included for clarity):
 
 - [x] Support RGBA and HSLA
 - [ ] Proper support for HEX with Alpha field (`#RRGGBBAA`)
-- [ ] Add a command to select the conversion in a floating window
+- [x] Add a command to select the conversion in a floating window
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ yourself. These functions are the following:
 ```lua
 {
   round_hsl = true, -- rounds saturation and light when generating HSL colors.
+  lowercase_hex = false, -- by default HEX colors will be uppercased.
   hsl_pattern = "hsl([h]deg [s] [l])",
   hsla_pattern = "hsl([h]deg [s] [l] / [a]%)",
   rgb_pattern = "rgb([r] [g] [b])",

--- a/lua/color-converter.lua
+++ b/lua/color-converter.lua
@@ -1,5 +1,6 @@
 local converter = require("color-converter.converter")
 local utils = require("color-converter.utils")
+local config = require("config")
 local M = {}
 
 -- {{{ Some local DRY utilities
@@ -11,9 +12,9 @@ local function from_HSL_to_RGB(color_line, opts)
   end
 
   local rgb_colors = converter.HSL_to_RGB(hsl.h, hsl.s, hsl.l, hsl.a)
-  local pattern = require("config").options.rgb_pattern
+  local pattern = config.options.rgb_pattern
   if hsl.a then
-    pattern = require("config").options.rgba_pattern
+    pattern = config.options.rgba_pattern
   end
 
   local new_color = utils.replace_tokens_in_pattern(pattern, {
@@ -32,6 +33,9 @@ local function from_HSL_to_Hex(color_line, opts)
   local hsl = utils.extract_hsl(color_line)
   if hsl then
     local hex_color = converter.HSL_to_Hex(hsl.h, hsl.s, hsl.l, hsl.a)
+    if config.options.lowercase_hex then
+      hex_color = hex_color:lower()
+    end
     if not opts.dry_run then
       vim.cmd(string.format("s/%s/%s", hsl.str:gsub("/", "\\/"), hex_color))
     end
@@ -46,13 +50,13 @@ local function from_RGB_to_HSL(color_line, opts)
   end
 
   local hsl_colors = converter.RGB_to_HSL(rgb.r, rgb.g, rgb.b, rgb.a)
-  local pattern = require("config").options.hsl_pattern
+  local pattern = config.options.hsl_pattern
   if rgb.a then
-    pattern = require("config").options.hsla_pattern
+    pattern = config.options.hsla_pattern
   end
 
   -- Apply rounding to saturation and lightness values.
-  if require("config").options.round_hsl then
+  if config.options.round_hsl then
     hsl_colors[2] = utils.round_float(hsl_colors[2], 0)
     hsl_colors[3] = utils.round_float(hsl_colors[3], 0)
   end
@@ -73,6 +77,9 @@ local function from_RGB_to_Hex(color_line, opts)
   local rgb = utils.extract_rgb(color_line)
   if rgb then
     local hex_color = converter.RGB_to_Hex(rgb.r, rgb.g, rgb.b, rgb.a)
+    if config.options.lowercase_hex then
+      hex_color = hex_color:lower()
+    end
     if not opts.dry_run then
       vim.cmd(string.format("s/%s/%s", rgb.str:gsub("/", "\\/"), hex_color))
     end
@@ -83,13 +90,13 @@ end
 local function from_Hex_to_HSL(color_line, opts)
   local hex = color_line:gmatch("(#%w+);?")()
   local hsl_color = converter.Hex_to_HSL(hex)
-  local pattern = require("config").options.hsl_pattern
+  local pattern = config.options.hsl_pattern
   if hsl_color[4] then
-    pattern = require("config").options.hsla_pattern
+    pattern = config.options.hsla_pattern
   end
 
   -- Apply rounding to saturation and lightness values.
-  if require("config").options.round_hsl then
+  if config.options.round_hsl then
     hsl_color[2] = utils.round_float(hsl_color[2], 0)
     hsl_color[3] = utils.round_float(hsl_color[3], 0)
   end
@@ -109,9 +116,9 @@ end
 local function from_Hex_to_RGB(color_line, opts)
   local hex = color_line:gmatch("(#%w+);?")()
   local rgb_color = converter.Hex_to_RGB(hex)
-  local pattern = require("config").options.rgb_pattern
+  local pattern = config.options.rgb_pattern
   if rgb_color[4] then
-    pattern = require("config").options.rgba_pattern
+    pattern = config.options.rgba_pattern
   end
 
   local new_color = utils.replace_tokens_in_pattern(pattern, {

--- a/lua/color-converter.lua
+++ b/lua/color-converter.lua
@@ -4,7 +4,7 @@ local M = {}
 
 -- {{{ Some local DRY utilities
 
-local function from_HSL_to_RGB(color_line)
+local function from_HSL_to_RGB(color_line, opts)
   local hsl = utils.extract_hsl(color_line)
   if not hsl then
     return
@@ -16,29 +16,30 @@ local function from_HSL_to_RGB(color_line)
     pattern = require("config").options.rgba_pattern
   end
 
-  vim.cmd(
-    string.format(
-      "s/%s/%s",
-      hsl.str:gsub("/", "\\/"),
-      utils.replace_tokens_in_pattern(pattern, {
-        r = rgb_colors[1],
-        g = rgb_colors[2],
-        b = rgb_colors[3],
-        a = rgb_colors[4],
-      })
-    )
-  )
+  local new_color = utils.replace_tokens_in_pattern(pattern, {
+    r = rgb_colors[1],
+    g = rgb_colors[2],
+    b = rgb_colors[3],
+    a = rgb_colors[4],
+  })
+  if not opts.dry_run then
+    vim.cmd(string.format("s/%s/%s", hsl.str:gsub("/", "\\/"), new_color))
+  end
+  return new_color
 end
 
-local function from_HSL_to_Hex(color_line)
+local function from_HSL_to_Hex(color_line, opts)
   local hsl = utils.extract_hsl(color_line)
   if hsl then
     local hex_color = converter.HSL_to_Hex(hsl.h, hsl.s, hsl.l, hsl.a)
-    vim.cmd(string.format("s/%s/%s", hsl.str:gsub("/", "\\/"), hex_color))
+    if not opts.dry_run then
+      vim.cmd(string.format("s/%s/%s", hsl.str:gsub("/", "\\/"), hex_color))
+    end
+    return hex_color
   end
 end
 
-local function from_RGB_to_HSL(color_line)
+local function from_RGB_to_HSL(color_line, opts)
   local rgb = utils.extract_rgb(color_line)
   if not rgb then
     return
@@ -56,28 +57,30 @@ local function from_RGB_to_HSL(color_line)
     hsl_colors[3] = utils.round_float(hsl_colors[3], 0)
   end
 
-  vim.cmd(
-    string.format(
-      "s/%s/%s",
-      rgb.str:gsub("/", "\\/"),
-      utils.replace_tokens_in_pattern(pattern, {
-        h = hsl_colors[1],
-        s = hsl_colors[2],
-        l = hsl_colors[3],
-        a = hsl_colors[4],
-      })
-    )
-  )
+  local new_color = utils.replace_tokens_in_pattern(pattern, {
+    h = hsl_colors[1],
+    s = hsl_colors[2],
+    l = hsl_colors[3],
+    a = hsl_colors[4],
+  })
+  if not opts.dry_run then
+    vim.cmd(string.format("s/%s/%s", rgb.str:gsub("/", "\\/"), new_color))
+  end
+  return new_color
 end
-local function from_RGB_to_Hex(color_line)
+
+local function from_RGB_to_Hex(color_line, opts)
   local rgb = utils.extract_rgb(color_line)
   if rgb then
     local hex_color = converter.RGB_to_Hex(rgb.r, rgb.g, rgb.b, rgb.a)
-    vim.cmd(string.format("s/%s/%s", rgb.str:gsub("/", "\\/"), hex_color))
+    if not opts.dry_run then
+      vim.cmd(string.format("s/%s/%s", rgb.str:gsub("/", "\\/"), hex_color))
+    end
+    return hex_color
   end
 end
 
-local function from_Hex_to_HSL(color_line)
+local function from_Hex_to_HSL(color_line, opts)
   local hex = color_line:gmatch("(#%w+);?")()
   local hsl_color = converter.Hex_to_HSL(hex)
   local pattern = require("config").options.hsl_pattern
@@ -91,19 +94,19 @@ local function from_Hex_to_HSL(color_line)
     hsl_color[3] = utils.round_float(hsl_color[3], 0)
   end
 
-  vim.cmd(string.format(
-    "s/%s/%s",
-    hex,
-    utils.replace_tokens_in_pattern(pattern, {
-      h = hsl_color[1],
-      s = hsl_color[2],
-      l = hsl_color[3],
-      a = hsl_color[4],
-    })
-  ))
+  local new_color = utils.replace_tokens_in_pattern(pattern, {
+    h = hsl_color[1],
+    s = hsl_color[2],
+    l = hsl_color[3],
+    a = hsl_color[4],
+  })
+  if not opts.dry_run then
+    vim.cmd(string.format("s/%s/%s", hex, new_color))
+  end
+  return new_color
 end
 
-local function from_Hex_to_RGB(color_line)
+local function from_Hex_to_RGB(color_line, opts)
   local hex = color_line:gmatch("(#%w+);?")()
   local rgb_color = converter.Hex_to_RGB(hex)
   local pattern = require("config").options.rgb_pattern
@@ -111,47 +114,47 @@ local function from_Hex_to_RGB(color_line)
     pattern = require("config").options.rgba_pattern
   end
 
-  vim.cmd(string.format(
-    "s/%s/%s",
-    hex,
-    utils.replace_tokens_in_pattern(pattern, {
-      r = rgb_color[1],
-      g = rgb_color[2],
-      b = rgb_color[3],
-      a = rgb_color[4],
-    })
-  ))
+  local new_color = utils.replace_tokens_in_pattern(pattern, {
+    r = rgb_color[1],
+    g = rgb_color[2],
+    b = rgb_color[3],
+    a = rgb_color[4],
+  })
+  if not opts.dry_run then
+    vim.cmd(string.format("s/%s/%s", hex, new_color))
+  end
+  return new_color
 end
 
 -- }}}
 
-M.to_rgb = function()
+M.to_rgb = function(opts)
   local current_line = vim.api.nvim_get_current_line()
 
   if current_line:find("hsl") then
-    from_HSL_to_RGB(current_line)
+    return from_HSL_to_RGB(current_line, opts or {})
   elseif current_line:find("#%w+") then
-    from_Hex_to_RGB(current_line)
+    return from_Hex_to_RGB(current_line, opts or {})
   end
 end
 
-M.to_hex = function()
+M.to_hex = function(opts)
   local current_line = vim.api.nvim_get_current_line()
 
   if current_line:find("rgb") then
-    from_RGB_to_Hex(current_line)
+    return from_RGB_to_Hex(current_line, opts or {})
   elseif current_line:find("hsl") then
-    from_HSL_to_Hex(current_line)
+    return from_HSL_to_Hex(current_line, opts or {})
   end
 end
 
-M.to_hsl = function()
+M.to_hsl = function(opts)
   local current_line = vim.api.nvim_get_current_line()
 
   if current_line:find("#%w+") then
-    from_Hex_to_HSL(current_line)
+    return from_Hex_to_HSL(current_line, opts or {})
   elseif current_line:find("rgb") then
-    from_RGB_to_HSL(current_line)
+    return from_RGB_to_HSL(current_line, opts or {})
   end
 end
 
@@ -165,14 +168,32 @@ M.cycle = function()
 
   -- Look for the color and its type, e.g. #21252a is an HEX color
   if current_line:find("rgb") then
-    from_RGB_to_HSL(current_line)
+    from_RGB_to_HSL(current_line, {})
   elseif current_line:find("#%w+") then
-    from_Hex_to_RGB(current_line)
+    from_Hex_to_RGB(current_line, {})
   elseif current_line:find("hsl") then
-    from_HSL_to_Hex(current_line)
+    from_HSL_to_Hex(current_line, {})
   end
 end
 
+--- Show a select list allowing the user to pick which format to convert to.
+M.pick = function()
+  vim.ui.select({ "hex", "rgb", "hsl" }, {
+    prompt = "Convert color to:",
+    format_item = function(item)
+      local new_color = M["to_" .. item]({ dry_run = true })
+      if new_color then
+        return item .. " [" .. new_color .. "]"
+      end
+      return item .. " [current]"
+    end,
+  }, function(item)
+    -- Run the function corresponding to the users's choice.
+    M["to_" .. item]()
+  end)
+end
+
+--- Setup function used to support user configuration.
 ---@param options Config: user defined configuration options.
 M.setup = function(options)
   require("config").__setup(options)

--- a/lua/color-converter.lua
+++ b/lua/color-converter.lua
@@ -3,9 +3,14 @@ local utils = require("color-converter.utils")
 local config = require("config")
 local M = {}
 
+---@alias color { type: "hsl" | "rgb" | "hex"; color_string: string; startpos: number; endpos: number }
+
 -- {{{ Some local DRY utilities
 
-local function from_HSL_to_RGB(color_line, opts)
+--- Converts an HSL color to a RGB color.
+--- @param color_line string -- the HSL color string.
+--- @return string|nil
+local function from_HSL_to_RGB(color_line)
   local hsl = utils.extract_hsl(color_line)
   if not hsl then
     return
@@ -17,33 +22,32 @@ local function from_HSL_to_RGB(color_line, opts)
     pattern = config.options.rgba_pattern
   end
 
-  local new_color = utils.replace_tokens_in_pattern(pattern, {
+  return utils.replace_tokens_in_pattern(pattern, {
     r = rgb_colors[1],
     g = rgb_colors[2],
     b = rgb_colors[3],
     a = rgb_colors[4],
   })
-  if not opts.dry_run then
-    vim.cmd(string.format("s/%s/%s", hsl.str:gsub("/", "\\/"), new_color))
-  end
-  return new_color
 end
 
-local function from_HSL_to_Hex(color_line, opts)
+--- Converts an HSL color to a HEX color.
+--- @param color_line string -- the HSL color string.
+--- @return string|nil
+local function from_HSL_to_Hex(color_line)
   local hsl = utils.extract_hsl(color_line)
   if hsl then
     local hex_color = converter.HSL_to_Hex(hsl.h, hsl.s, hsl.l, hsl.a)
     if config.options.lowercase_hex then
       hex_color = hex_color:lower()
     end
-    if not opts.dry_run then
-      vim.cmd(string.format("s/%s/%s", hsl.str:gsub("/", "\\/"), hex_color))
-    end
     return hex_color
   end
 end
 
-local function from_RGB_to_HSL(color_line, opts)
+--- Converts a RGB color to an HSL color.
+--- @param color_line string -- the RGB color string.
+--- @return string|nil
+local function from_RGB_to_HSL(color_line)
   local rgb = utils.extract_rgb(color_line)
   if not rgb then
     return
@@ -61,35 +65,33 @@ local function from_RGB_to_HSL(color_line, opts)
     hsl_colors[3] = utils.round_float(hsl_colors[3], 0)
   end
 
-  local new_color = utils.replace_tokens_in_pattern(pattern, {
+  return utils.replace_tokens_in_pattern(pattern, {
     h = hsl_colors[1],
     s = hsl_colors[2],
     l = hsl_colors[3],
     a = hsl_colors[4],
   })
-  if not opts.dry_run then
-    vim.cmd(string.format("s/%s/%s", rgb.str:gsub("/", "\\/"), new_color))
-  end
-  return new_color
 end
 
-local function from_RGB_to_Hex(color_line, opts)
+--- Converts a RGB color to a HEX color.
+--- @param color_line string -- the RGB color string.
+--- @return string|nil
+local function from_RGB_to_Hex(color_line)
   local rgb = utils.extract_rgb(color_line)
   if rgb then
     local hex_color = converter.RGB_to_Hex(rgb.r, rgb.g, rgb.b, rgb.a)
     if config.options.lowercase_hex then
       hex_color = hex_color:lower()
     end
-    if not opts.dry_run then
-      vim.cmd(string.format("s/%s/%s", rgb.str:gsub("/", "\\/"), hex_color))
-    end
     return hex_color
   end
 end
 
-local function from_Hex_to_HSL(color_line, opts)
-  local hex = color_line:gmatch("(#%w+);?")()
-  local hsl_color = converter.Hex_to_HSL(hex)
+--- Converts a HEX color to an HSL color.
+--- @param color_line string -- the HEX color string.
+--- @return string|nil
+local function from_Hex_to_HSL(color_line)
+  local hsl_color = converter.Hex_to_HSL(color_line)
   local pattern = config.options.hsl_pattern
   if hsl_color[4] then
     pattern = config.options.hsla_pattern
@@ -101,90 +103,186 @@ local function from_Hex_to_HSL(color_line, opts)
     hsl_color[3] = utils.round_float(hsl_color[3], 0)
   end
 
-  local new_color = utils.replace_tokens_in_pattern(pattern, {
+  return utils.replace_tokens_in_pattern(pattern, {
     h = hsl_color[1],
     s = hsl_color[2],
     l = hsl_color[3],
     a = hsl_color[4],
   })
-  if not opts.dry_run then
-    vim.cmd(string.format("s/%s/%s", hex, new_color))
-  end
-  return new_color
 end
 
-local function from_Hex_to_RGB(color_line, opts)
-  local hex = color_line:gmatch("(#%w+);?")()
-  local rgb_color = converter.Hex_to_RGB(hex)
+--- Converts a HEX color to an HSL color.
+--- @param color_line string -- the HEX color string.
+--- @return string|nil
+local function from_Hex_to_RGB(color_line)
+  local rgb_color = converter.Hex_to_RGB(color_line)
   local pattern = config.options.rgb_pattern
   if rgb_color[4] then
     pattern = config.options.rgba_pattern
   end
 
-  local new_color = utils.replace_tokens_in_pattern(pattern, {
+  return utils.replace_tokens_in_pattern(pattern, {
     r = rgb_color[1],
     g = rgb_color[2],
     b = rgb_color[3],
     a = rgb_color[4],
   })
-  if not opts.dry_run then
-    vim.cmd(string.format("s/%s/%s", hex, new_color))
+end
+
+--- Gets the color under the cursor, if any.
+--- @return color|nil
+local function get_color_under_cursor()
+  local current_line = vim.api.nvim_get_current_line()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local cursor_col = cursor[2]
+
+  for startpos, match, endpos in current_line:gmatch("()(hsla?%([^)]+%))()") do
+    if startpos - 1 <= cursor_col and endpos - 2 >= cursor_col then
+      return {
+        type = "hsl",
+        color_string = match,
+        startpos = startpos,
+        endpos = endpos - 1,
+      }
+    end
   end
-  return new_color
+  for startpos, match, endpos in current_line:gmatch("()(rgba?%([^)]+%))()") do
+    if startpos - 1 <= cursor_col and endpos - 2 >= cursor_col then
+      return {
+        type = "rgb",
+        color_string = match,
+        startpos = startpos,
+        endpos = endpos - 1,
+      }
+    end
+  end
+  for startpos, match, endpos in current_line:gmatch("()(#%w+)()") do
+    if startpos - 1 <= cursor_col and endpos - 2 >= cursor_col then
+      return {
+        type = "hex",
+        color_string = match,
+        startpos = startpos,
+        endpos = endpos - 1,
+      }
+    end
+  end
+
+  return nil
+end
+
+--- Replaces the color under the cursor with a new one.
+--- @param color color -- the color to replace.
+--- @param replacement_string string -- the new color to replace the old one with.
+local function replace_color_under_cursor(color, replacement_string)
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  vim.api.nvim_buf_set_text(
+    0,
+    cursor[1] - 1,
+    color.startpos - 1,
+    cursor[1] - 1,
+    color.endpos,
+    { replacement_string }
+  )
 end
 
 -- }}}
 
 M.to_rgb = function(opts)
-  local current_line = vim.api.nvim_get_current_line()
-
-  if current_line:find("hsl") then
-    return from_HSL_to_RGB(current_line, opts or {})
-  elseif current_line:find("#%w+") then
-    return from_Hex_to_RGB(current_line, opts or {})
+  opts = opts or {}
+  local current_color = get_color_under_cursor()
+  if not current_color then
+    return nil
   end
+
+  local new_color
+  if current_color.type == "hsl" then
+    new_color = from_HSL_to_RGB(current_color.color_string)
+  elseif current_color.type == "hex" then
+    new_color = from_Hex_to_RGB(current_color.color_string)
+  end
+
+  -- Replace the old color with the new color, it not in dry run mode.
+  if not opts.dry_run and new_color then
+    replace_color_under_cursor(current_color, new_color)
+  end
+  return new_color
 end
 
 M.to_hex = function(opts)
-  local current_line = vim.api.nvim_get_current_line()
-
-  if current_line:find("rgb") then
-    return from_RGB_to_Hex(current_line, opts or {})
-  elseif current_line:find("hsl") then
-    return from_HSL_to_Hex(current_line, opts or {})
+  opts = opts or {}
+  local current_color = get_color_under_cursor()
+  if not current_color then
+    return nil
   end
+
+  local new_color
+  if current_color.type == "rgb" then
+    new_color = from_RGB_to_Hex(current_color.color_string)
+  elseif current_color.type == "hsl" then
+    new_color = from_HSL_to_Hex(current_color.color_string)
+  end
+
+  -- Replace the old color with the new color, it not in dry run mode.
+  if not opts.dry_run and new_color then
+    replace_color_under_cursor(current_color, new_color)
+  end
+  return new_color
 end
 
 M.to_hsl = function(opts)
-  local current_line = vim.api.nvim_get_current_line()
-
-  if current_line:find("#%w+") then
-    return from_Hex_to_HSL(current_line, opts or {})
-  elseif current_line:find("rgb") then
-    return from_RGB_to_HSL(current_line, opts or {})
+  opts = opts or {}
+  local current_color = get_color_under_cursor()
+  if not current_color then
+    return nil
   end
+
+  local new_color
+  if current_color.type == "rgb" then
+    new_color = from_RGB_to_HSL(current_color.color_string)
+  elseif current_color.type == "hex" then
+    new_color = from_Hex_to_HSL(current_color.color_string)
+  end
+
+  -- Replace the old color with the new color, it not in dry run mode.
+  if not opts.dry_run and new_color then
+    replace_color_under_cursor(current_color, new_color)
+  end
+
+  return new_color
 end
 
 -- cycle will cycle the colors, e.g. HEX => RGB => HSL => HEX
 M.cycle = function()
-  -- NOTE: the cycle order is the following:
-  --       HEX => RGB => HSL => HEX
+  -- NOTE: The cycle order is the following: HEX => RGB => HSL => HEX.
 
-  -- Get the current line in the buffer
-  local current_line = vim.api.nvim_get_current_line()
+  local current_color = get_color_under_cursor()
+  if not current_color then
+    return nil
+  end
 
-  -- Look for the color and its type, e.g. #21252a is an HEX color
-  if current_line:find("rgb") then
-    from_RGB_to_HSL(current_line, {})
-  elseif current_line:find("#%w+") then
-    from_Hex_to_RGB(current_line, {})
-  elseif current_line:find("hsl") then
-    from_HSL_to_Hex(current_line, {})
+  local new_color
+  if current_color.type == "rgb" then
+    new_color = from_RGB_to_HSL(current_color.color_string)
+  elseif current_color.type == "hex" then
+    new_color = from_Hex_to_RGB(current_color.color_string)
+  elseif current_color.type == "hsl" then
+    new_color = from_HSL_to_Hex(current_color.color_string)
+  end
+
+  if new_color then
+    replace_color_under_cursor(current_color, new_color)
   end
 end
 
 --- Show a select list allowing the user to pick which format to convert to.
 M.pick = function()
+  local current_color = get_color_under_cursor()
+  if not current_color then
+    print("No color found under the cursor.")
+    return
+  end
+
+  local cursor = vim.api.nvim_win_get_cursor(0)
   vim.ui.select({ "hex", "rgb", "hsl" }, {
     prompt = "Convert color to:",
     format_item = function(item)
@@ -195,6 +293,8 @@ M.pick = function()
       return item .. " [current]"
     end,
   }, function(item)
+    -- Ensure that the original cursor position is restored.
+    vim.api.nvim_win_set_cursor(0, cursor)
     -- Run the function corresponding to the users's choice.
     M["to_" .. item]()
   end)

--- a/lua/color-converter/utils.lua
+++ b/lua/color-converter/utils.lua
@@ -100,7 +100,7 @@ end
 --- @param tokens table -- a table of tokens keyed by token name.
 --- @return string -- the pattern with tokens replaced.
 M.replace_tokens_in_pattern = function(pattern, tokens)
-  pattern = pattern:gsub("%%", "%%"):gsub("/", "\\/")
+  pattern = pattern:gsub("%%", "%%")
   for k, v in pairs(tokens) do
     -- Try to replace percentage placeholders first.
     if pattern:match("%[" .. k .. "%]%%") then

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -5,6 +5,7 @@ local M = {}
 
 M.defaults = {
   round_hsl = true,
+  lowercase_hex = false,
   hsl_pattern = "hsl([h]deg [s] [l])",
   hsla_pattern = "hsl([h]deg [s] [l] / [a]%)",
   rgb_pattern = "rgb([r] [g] [b])",
@@ -13,6 +14,7 @@ M.defaults = {
 
 ---@class Config
 ---@field round_hsl boolean: whether to apply rounding when generating hsl colors.
+---@field lowercase_hex boolean: true if hex colors should be lowercased, false otherwise.
 ---@field hsl_pattern string: the hsl pattern used when generating colors.
 ---@field hsla_pattern string: the hsla pattern used when generating colors.
 ---@field rgb_pattern string: the rgb pattern used when generating colors.


### PR DESCRIPTION
I have closed two other PRs in favor of this one.
The PR contains the following features/improvements:
- Config option for lower-casing HEX codes.
- Adds a picker to select the format and preview the new color before updating it.
- Respect the cursor position.
   This allows replacing a specific color when there are multiple colors on the same line.
   Now you have to move the cursor to the color before converting it, if the cursor is not on a color, the plugin will do nothing.
   The cursor no longer jumps to the beginning of the line when replacing a color, this is because I use `vim.api.nvim_buf_set_text` instead of the substitution command.

![image](https://github.com/user-attachments/assets/c63d8a64-b434-48cc-b37c-d8acafa2015a)

https://github.com/user-attachments/assets/18c80557-8b8e-4c95-a9b1-503ac1303972


