### PR TITLE
feat: added an option to detect the color on the entire line

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ yourself. These functions are the following:
 {
   round_hsl = true, -- rounds saturation and light when generating HSL colors.
   lowercase_hex = false, -- by default HEX colors will be uppercased.
+  detect_entire_line = false, -- detects color only under the cursor by default, detects the first color on the entire line if set to true
   hsl_pattern = "hsl([h]deg [s] [l])",
   hsla_pattern = "hsl([h]deg [s] [l] / [a]%)",
   rgb_pattern = "rgb([r] [g] [b])",

--- a/lua/color-converter.lua
+++ b/lua/color-converter.lua
@@ -131,43 +131,56 @@ end
 
 --- Gets the color under the cursor, if any.
 --- @return color|nil
-local function get_color_under_cursor()
+
+local function get_color()
   local current_line = vim.api.nvim_get_current_line()
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local cursor_col = cursor[2]
+  local cursor_col = vim.api.nvim_win_get_cursor(0)[2]
+  local detect_line = config.options.detect_entire_line
+
+  local matches = {}
+
+  local function check_match(startpos, endpos)
+    if detect_line then
+      return true
+    end
+    return startpos - 1 <= cursor_col and endpos - 2 >= cursor_col
+  end
 
   for startpos, match, endpos in current_line:gmatch("()(hsla?%([^)]+%))()") do
-    if startpos - 1 <= cursor_col and endpos - 2 >= cursor_col then
-      return {
+    if check_match(startpos, endpos) then
+      table.insert(matches, {
         type = "hsl",
         color_string = match,
         startpos = startpos,
         endpos = endpos - 1,
-      }
+      })
     end
   end
+
   for startpos, match, endpos in current_line:gmatch("()(rgba?%([^)]+%))()") do
-    if startpos - 1 <= cursor_col and endpos - 2 >= cursor_col then
-      return {
+    if check_match(startpos, endpos) then
+      table.insert(matches, {
         type = "rgb",
         color_string = match,
         startpos = startpos,
         endpos = endpos - 1,
-      }
+      })
     end
   end
-  for startpos, match, endpos in current_line:gmatch("()(#%w+)()") do
-    if startpos - 1 <= cursor_col and endpos - 2 >= cursor_col then
-      return {
+
+  for startpos, match, endpos in current_line:gmatch("()(#%x%x%x%x%x%x)()") do
+    if check_match(startpos, endpos) then
+      table.insert(matches, {
         type = "hex",
         color_string = match,
         startpos = startpos,
         endpos = endpos - 1,
-      }
+      })
     end
   end
 
-  return nil
+  -- pick the first match if there's more than one
+  return matches[1]
 end
 
 --- Replaces the color under the cursor with a new one.
@@ -189,7 +202,7 @@ end
 
 M.to_rgb = function(opts)
   opts = opts or {}
-  local current_color = get_color_under_cursor()
+  local current_color = get_color()
   if not current_color then
     return nil
   end
@@ -210,7 +223,7 @@ end
 
 M.to_hex = function(opts)
   opts = opts or {}
-  local current_color = get_color_under_cursor()
+  local current_color = get_color()
   if not current_color then
     return nil
   end
@@ -231,7 +244,7 @@ end
 
 M.to_hsl = function(opts)
   opts = opts or {}
-  local current_color = get_color_under_cursor()
+  local current_color = get_color()
   if not current_color then
     return nil
   end
@@ -255,7 +268,7 @@ end
 M.cycle = function()
   -- NOTE: The cycle order is the following: HEX => RGB => HSL => HEX.
 
-  local current_color = get_color_under_cursor()
+  local current_color = get_color()
   if not current_color then
     return nil
   end
@@ -276,7 +289,7 @@ end
 
 --- Show a select list allowing the user to pick which format to convert to.
 M.pick = function()
-  local current_color = get_color_under_cursor()
+  local current_color = get_color()
   if not current_color then
     print("No color found under the cursor.")
     return

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -6,6 +6,7 @@ local M = {}
 M.defaults = {
   round_hsl = true,
   lowercase_hex = false,
+  detect_entire_line = false,
   hsl_pattern = "hsl([h]deg [s] [l])",
   hsla_pattern = "hsl([h]deg [s] [l] / [a]%)",
   rgb_pattern = "rgb([r] [g] [b])",
@@ -15,6 +16,7 @@ M.defaults = {
 ---@class Config
 ---@field round_hsl boolean: whether to apply rounding when generating hsl colors.
 ---@field lowercase_hex boolean: true if hex colors should be lowercased, false otherwise.
+---@field detect_entire_line boolean: detects the color on the current line if true, otherwise on the cursor
 ---@field hsl_pattern string: the hsl pattern used when generating colors.
 ---@field hsla_pattern string: the hsla pattern used when generating colors.
 ---@field rgb_pattern string: the rgb pattern used when generating colors.


### PR DESCRIPTION
I noticed that I cannot do any actions on the color unless the cursor is directly on it. Previously, it wan't like that, it used to be possible to make actions even if you're just on the line that contains the color, so I added an option `detect_entire_line` which is a boolean that is set to `false` by default that allows you to take action on the first color to be found on the current line if set to `true`.